### PR TITLE
Protect Poll and send

### DIFF
--- a/srcs/PollHandler.cpp
+++ b/srcs/PollHandler.cpp
@@ -42,11 +42,7 @@ namespace Webserver
 		{
 			if (_fds[i].revents & POLLIN || _fds[i].revents & POLLHUP)
 				_subscribers[i]->onRead();
-		}
-
-		for (size_t i = 0; i < _fds.size(); i++)
-		{
-			if (_fds[i].revents & POLLOUT)
+			else if (_fds[i].revents & POLLOUT)
 				_subscribers[i]->onWrite();
 		}
 	}

--- a/srcs/Sender.cpp
+++ b/srcs/Sender.cpp
@@ -1,6 +1,7 @@
 #include <Sender.hpp>
 #include <defines.hpp>
 #include <Logger.hpp>
+#include <Client.hpp>
 
 #include <iostream>
 #include <string>
@@ -73,6 +74,8 @@ namespace Webserver
 		{
 			ssize_t written;
 			written = write(_fd, _buffer, bufferBytesFilled);
+			if (written == 0)
+				throw Client::DisconnectedException();
 			DEBUG("Bytes sent to client(" << _fd << "): " << bufferBytesFilled);
 		}
 		if (_currentState == FINISHED)


### PR DESCRIPTION
Write in sender is protected by throwing Client::DisconnectedException if the return value == 0.
PollHandler will respectively receive or send in a single iteration (instead of read and send if both are flagged).
Reason is because the subject is a bit vague about this. For the program I don't consider it neccesary though.